### PR TITLE
Optimize error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# Environments
 .env
+.venv
+venv
+
+# Byte-compiled / optimized / DLL files
 __pycache__

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Set the values with the Instance Domain, Client ID, and Client Secret from the p
 2. Start the server with `python3 server.py`
 3. Open another terminal and follow the next step to test the API
 
+You can optionally create a virtual environment before installing the dependencies by running `python3 -m venv venv`
+
 ## Testing the API
 
 ### Public route

--- a/test_validator.py
+++ b/test_validator.py
@@ -1,5 +1,15 @@
 import unittest
 from validator import ZitadelIntrospectTokenValidator as v
+from validator import ValidatorError
+
+class TestValidatorToken(unittest.TestCase):
+    def test_invalid_token(self):
+        token = {'active': False}
+        scopes = None
+        request = None
+        with self.assertRaises(ValidatorError) as error: 
+            v.validate_token(None, token, scopes, request)
+        self.assertEqual("{'code': 'invalid_token', 'description': 'Invalid token (active: false)'}", str(error.exception.error))
 
 class TestValidatorMatchTokenScopes(unittest.TestCase):
 

--- a/validator.py
+++ b/validator.py
@@ -50,6 +50,11 @@ class ZitadelIntrospectTokenValidator(IntrospectTokenValidator):
         now = int( time.time() )
         if not token:
             raise ValidatorError({
+                "code": "invalid_token", 
+                "description": "Invalid Token." }, 401)
+        """Revoked"""
+        if not token["active"]: 
+            raise ValidatorError({
                 "code": "invalid_token_revoked", 
                 "description": "Token was revoked." }, 401)
         """Expired"""
@@ -57,9 +62,6 @@ class ZitadelIntrospectTokenValidator(IntrospectTokenValidator):
             raise ValidatorError({
                 "code": "invalid_token_expired", 
                 "description": "Token has expired." }, 401)
-        """Revoked"""
-        if not token["active"]: 
-            raise InvalidTokenError()
         """Insufficient Scope"""
         if not self.match_token_scopes(token, scopes):
             raise ValidatorError({

--- a/validator.py
+++ b/validator.py
@@ -55,8 +55,8 @@ class ZitadelIntrospectTokenValidator(IntrospectTokenValidator):
         """Revoked"""
         if not token["active"]: 
             raise ValidatorError({
-                "code": "invalid_token_revoked", 
-                "description": "Token was revoked." }, 401)
+                "code": "invalid_token", 
+                "description": "Invalid token (active: false)" }, 401)
         """Expired"""
         if token["exp"] < now: 
             raise ValidatorError({


### PR DESCRIPTION
- Add note about venv
- Check first if response is {"active": false} (meaning invalid token)
- Add test for tokenvalidator